### PR TITLE
Jdpopkin current buffer agenda

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,14 +4,18 @@
   This log is kept according to the [[http://keepachangelog.com/][Keep a CHANGELOG]] manifesto
 ** 0.6.0                  					 :unreleased:
 *** Added
+    - =g:org_aggressive_conceal=, if value =1=, will conceal all simple format
+      identifying characters, default =0=. (merges PR #188)
+    - (testing on `g:org_aggressive_conceal=1' mode) Add possibility to escape
+      format indicating characters from leading inline markup, by escaping with
+      "\".
     - Add alternative behavior: refrain from entering insert mode after
       heading/checkbox creation through keybindings. Activate by setting
       =g:org_prefer_insert_mode= to 0. (closes issue #211)
     - Add export as LaTeX beamer slides (merges PR #206)
     - Keybinding to create plainlist item directly. (closes issue #190)
-    - =g:org_aggressive_conceal=, if value =1=, will conceal all simple format
-      identifying characters, default =0=. (merges PR #188)
 *** Changed
+    - In [[syntax/org.vim][syntax/org.vim]], changed `\@<=' with computational faster `\zs'
     - Using =<localleader>c[n/N]= to create new plainlist item following
       current plainlist item. Now these keybindings will unconditionally
       create empty checkbox. (issue #190)

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -23,6 +23,7 @@
     - Nothing
 *** Removed
 *** Fixed
+    - Fix =concealcursor= mis-setting. (from ="nc"= to =nc=)
     - Fix duplicate =InsertLeave= autocmd for =tag_complete=(close issue #223)
     - Fix utl error when =\= or white space is in the link by auto-escaping(issue #220)
     - Fix typo vbm -> vmb (merges PR #219.)

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,8 @@
       =g:org_prefer_insert_mode= to 0. (closes issue #211)
     - Add export as LaTeX beamer slides (merges PR #206)
     - Keybinding to create plainlist item directly. (closes issue #190)
+    - =g:org_aggressive_conceal=, if value =1=, will conceal all simple format
+      identifying characters, default =0=.
 *** Changed
     - Using =<localleader>c[n/N]= to create new plainlist item following
       current plainlist item. Now these keybindings will unconditionally

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,7 @@
   This log is kept according to the [[http://keepachangelog.com/][Keep a CHANGELOG]] manifesto
 ** 0.6.0                  					 :unreleased:
 *** Added
+    - Implementing agenda overview for current buffer. (merges PR #229)
     - =g:org_aggressive_conceal=, if value =1=, will conceal all simple format
       identifying characters, default =0=. (merges PR #188)
     - (testing on `g:org_aggressive_conceal=1' mode) Add possibility to escape

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,7 +10,7 @@
     - Add export as LaTeX beamer slides (merges PR #206)
     - Keybinding to create plainlist item directly. (closes issue #190)
     - =g:org_aggressive_conceal=, if value =1=, will conceal all simple format
-      identifying characters, default =0=.
+      identifying characters, default =0=. (merges PR #188)
 *** Changed
     - Using =<localleader>c[n/N]= to create new plainlist item following
       current plainlist item. Now these keybindings will unconditionally

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,7 +17,8 @@
     - Nothing
 *** Removed
 *** Fixed
-    - Fixed utl error when =\= or white space is in the link by auto-escaping(issue #220)
+    - Fix duplicate =InsertLeave= autocmd for =tag_complete=(close issue #223)
+    - Fix utl error when =\= or white space is in the link by auto-escaping(issue #220)
     - Fix typo vbm -> vmb (merges PR #219.)
       instance in document on NeoVim.(closes issue #213)
     - Fix toggling checkboxes with plain embedded lists (closes issue #209)

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -27,6 +27,7 @@
     - Return to right window before setting todo (closes issue #202)
     - Fix link to calendar-vim (closes issue #197)
     - Fix `out of bound` issue when creating heading/checkbox after last
+      instance in document on NeoVim.
 ** 0.5.0 <2015-10-10 Sat>							 :released:
 *** Added
     - show link description in headings when folded, instead of the whole

--- a/README.org
+++ b/README.org
@@ -1,5 +1,8 @@
 * Vim-OrgMode
 
+  #+ATTR_HTML: title="Join the chat at https://gitter.im/jceb/vim-orgmode"
+  [[https://gitter.im/jceb/vim-orgmode?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge][file:https://badges.gitter.im/jceb/vim-orgmode.svg]]
+
   [[https://secure.travis-ci.org/jceb/vim-orgmode.png?branch=master]]
 
   Text outlining and task management for Vim based on [[http://orgmode.org/][Emacs' Org-Mode]].

--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -154,7 +154,7 @@ via the 'Org' menu. Most are only usable in command mode.
     <C-S-Right>     - next keyword set
 
   Plain List:~
-    <localleader>cl or <CR>     - insert plainlist item below 
+    <localleader>cl or <CR>     - insert plainlist item below
     <localleader>cL or <C-S-CR> - insert plainlist item above
 
   Checkboxes:~
@@ -1196,6 +1196,17 @@ syntax highlighting and indentation~
   Syntax highlighting is customizable to fit nicely with the user's
   colorscheme.
 
+                                                      *g:org_aggressive_conceal*
+  Default: 0
+  Defines if format indicating characters for inline markups(bold, italic,
+  inline code, verbatims, in-file hyper-link, etc.) are displayed. Format
+  indicating characters will be concealed if value is `1`, rendering a much
+  cleaner view. However, since this feature is newly introduced(<2016-04-08>)
+  and still need further testing. It is inactive by default. Example:
+>
+  let g:org_aggressive_conceal = 0
+<
+
                                                 *g:org_heading_highlight_colors*
   Default: ['Title', 'Constant', 'Identifier', 'Statement', 'PreProc', 'Type',
           \ 'Special']
@@ -1222,15 +1233,6 @@ syntax highlighting and indentation~
   let g:org_heading_shade_leading_stars = 1
 <
 
-                                                      *g:org_aggressive_conceal*
-  Default: 0
-  Defines if format indicating characters are displayed. Format indicating
-  characters will be concealed if value is `1`, rendering a cleaner view.
-  Note that, strings indicating formatting information such as `#+BEGIN_SRC`
-  and `#+END_SRC` will not be affected. They will always be displayed. Example:
->
-  let g:org_aggressive_conceal = 0
-<
                                                            *g:org_todo_keywords*
   Default: ['TODO', '|', 'DONE']
   Defines the keywords that are highlighted in headings. For more information

--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -1222,6 +1222,15 @@ syntax highlighting and indentation~
   let g:org_heading_shade_leading_stars = 1
 <
 
+                                                      *g:org_aggressive_conceal*
+  Default: 0
+  Defines if format indicating characters are displayed. Format indicating
+  characters will be concealed if value is `1`, rendering a cleaner view.
+  Note that, strings indicating formatting information such as `#+BEGIN_SRC`
+  and `#+END_SRC` will not be affected. They will always be displayed. Example:
+>
+  let g:org_aggressive_conceal = 0
+<
                                                            *g:org_todo_keywords*
   Default: ['TODO', '|', 'DONE']
   Defines the keywords that are highlighted in headings. For more information

--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -174,9 +174,11 @@ via the 'Org' menu. Most are only usable in command mode.
   Agenda:~
     <localleader>caa    - agenda for the week
     <localleader>cat    - agenda of all TODOs
+    <localleader>caA    - agenda for the week for current buffer
+    <localleader>caT    - agenda of all TODOs for current buffer
 
     Not yet implemented in vim-orgmode~
-    <localleader>caT    - timeline for current buffer
+    <localleader>caL    - timeline of current buffer
 
   Export:~
     <localleader>ep     - export as PDF

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -51,6 +51,12 @@ if ! exists('g:org_syntax_highlight_leading_stars') && ! exists('b:org_syntax_hi
 	let g:org_syntax_highlight_leading_stars = 1
 endif
 
+
+" setting to conceal aggresively
+if ! exists('g:org_aggressive_conceal') && ! exists('b:org_aggressive_conceal')
+	let g:org_aggressive_conceal = 0
+endif
+
 " Defined in separate plugins
 " Adding Behavior preference:
 "       1:          go into insert-mode when new heading/checkbox/plainlist added

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -11,11 +11,12 @@ if ! has('python') || v:version < 703
 	finish
 endif
 
+" Init buffer for file {{{1
 if ! exists('b:did_ftplugin')
 	" default emacs settings
 	setlocal comments=fb:*,b:#,fb:-
 	setlocal commentstring=#\ %s
-	setlocal conceallevel=2 concealcursor="nc"
+	setlocal conceallevel=2 concealcursor=nc
 	" original emacs settings are: setlocal tabstop=6 shiftwidth=6, but because
 	" of checkbox indentation the following settings are used:
 	setlocal tabstop=6 shiftwidth=6
@@ -50,7 +51,6 @@ endif
 if ! exists('g:org_syntax_highlight_leading_stars') && ! exists('b:org_syntax_highlight_leading_stars')
 	let g:org_syntax_highlight_leading_stars = 1
 endif
-
 
 " setting to conceal aggresively
 if ! exists('g:org_aggressive_conceal') && ! exists('b:org_aggressive_conceal')

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -53,7 +53,7 @@ if ! exists('g:org_syntax_highlight_leading_stars') && ! exists('b:org_syntax_hi
 endif
 
 " setting to conceal aggresively
-if ! exists('g:org_aggressive_conceal') && ! exists('b:org_aggressive_conceal')
+if ! exists('g:org_aggressive_conceal')
 	let g:org_aggressive_conceal = 0
 endif
 

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -140,6 +140,11 @@ class Agenda(object):
 		raw_agenda = ORGMODE.agenda_manager.get_next_week_and_active_todo(
 			agenda_documents)
 
+		# if raw_agenda is empty, return directly
+		if not raw_agenda:
+			vim.command('echom "All caught-up. No agenda or active todo next week."')
+			return
+
 		# create buffer at bottom
 		cmd = [u'setlocal filetype=orgagenda', ]
 		cls._switch_to(u'AGENDA', cmd)

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -280,7 +280,7 @@ class Agenda(object):
 		)
 		add_cmd_mapping_menu(
 			self,
-			name=u"OrgAgendaTodoBuffer",
+			name=u"OrgBufferAgendaTodo",
 			function=u':py ORGMODE.plugins[u"Agenda"].list_all_todos(current_buffer=True)',
 			key_mapping=u'<localleader>caT',
 			menu_desrc=u'Agenda for all TODOs based on current buffer'
@@ -294,7 +294,7 @@ class Agenda(object):
 		)
 		add_cmd_mapping_menu(
 			self,
-			name=u"OrgAgendaWeekBuffer",
+			name=u"OrgBufferAgendaWeek",
 			function=u':py ORGMODE.plugins[u"Agenda"].list_next_week_for_buffer()',
 			key_mapping=u'<localleader>caA',
 			menu_desrc=u'Agenda for the week based on current buffer'

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -208,14 +208,21 @@ class Agenda(object):
 			pass
 
 	@classmethod
-	def list_all_todos(cls):
+	def list_all_todos(cls, current_buffer=False):
 		u"""
-		List all todos in all agenda files in one buffer.
+		List all todos in:
+			current_buffer = False 		all agenda files
+			current_buffer = True 		current org_file
+		in one buffer.
 		"""
-		agenda_documents = cls._get_agendadocuments()
-		if not agenda_documents:
+		if current_buffer:
+			agenda_documents = vim.current.buffer.name
+			loaded_agendafiles = cls._load_agendafiles([agenda_documents])
+		else:
+			loaded_agendafiles = cls._get_agendadocuments()
+		if not loaded_agendafiles:
 			return
-		raw_agenda = ORGMODE.agenda_manager.get_todo(agenda_documents)
+		raw_agenda = ORGMODE.agenda_manager.get_todo(loaded_agendafiles)
 
 		cls.line2doc = {}
 		# create buffer at bottom
@@ -273,6 +280,13 @@ class Agenda(object):
 		)
 		add_cmd_mapping_menu(
 			self,
+			name=u"OrgAgendaTodoBuffer",
+			function=u':py ORGMODE.plugins[u"Agenda"].list_all_todos(current_buffer=True)',
+			key_mapping=u'<localleader>caT',
+			menu_desrc=u'Agenda for all TODOs based on current buffer'
+		)
+		add_cmd_mapping_menu(
+			self,
 			name=u"OrgAgendaWeek",
 			function=u':py ORGMODE.plugins[u"Agenda"].list_next_week()',
 			key_mapping=u'<localleader>caa',
@@ -280,9 +294,9 @@ class Agenda(object):
 		)
 		add_cmd_mapping_menu(
 			self,
-			name=u"OrgAgendaBuffer",
+			name=u"OrgAgendaWeekBuffer",
 			function=u':py ORGMODE.plugins[u"Agenda"].list_next_week_for_buffer()',
-			key_mapping=u'<localleader>caT',
+			key_mapping=u'<localleader>caA',
 			menu_desrc=u'Agenda for the week based on current buffer'
 		)
 		add_cmd_mapping_menu(

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -77,7 +77,10 @@ class Agenda(object):
 				u"g:org_agenda_files=['~/org/index.org'] to add "
 				u"files to the agenda view."))
 			return
+		return self._load_agendafiles(agenda_files)
 
+	@classmethod
+	def _load_agendafiles(self, agenda_files):
 		# glob for files in agenda_files
 		resolved_files = []
 		for f in agenda_files:
@@ -137,6 +140,17 @@ class Agenda(object):
 		agenda_documents = cls._get_agendadocuments()
 		if not agenda_documents:
 			return
+		cls.list_next_week_for(agenda_documents)
+
+	@classmethod
+	def list_next_week_for_buffer(cls):
+		agenda_documents = vim.current.buffer.name
+		loaded_agendafiles = cls._load_agendafiles([agenda_documents])
+		cls.list_next_week_for(loaded_agendafiles)
+
+
+	@classmethod
+	def list_next_week_for(cls, agenda_documents):
 		raw_agenda = ORGMODE.agenda_manager.get_next_week_and_active_todo(
 			agenda_documents)
 
@@ -263,6 +277,13 @@ class Agenda(object):
 			function=u':py ORGMODE.plugins[u"Agenda"].list_next_week()',
 			key_mapping=u'<localleader>caa',
 			menu_desrc=u'Agenda for the week'
+		)
+		add_cmd_mapping_menu(
+			self,
+			name=u"OrgAgendaBuffer",
+			function=u':py ORGMODE.plugins[u"Agenda"].list_next_week_for_buffer()',
+			key_mapping=u'<localleader>caT',
+			menu_desrc=u'Agenda for the week based on current buffer'
 		)
 		add_cmd_mapping_menu(
 			self,

--- a/ftplugin/orgmode/plugins/TagsProperties.py
+++ b/ftplugin/orgmode/plugins/TagsProperties.py
@@ -198,9 +198,9 @@ endif
 endfunction""".encode(u'utf-8'))
 
 		vim.command(u"""function Org_realign_tags_on_insert_leave()
-if !exists('b:org_insert_leave_set')
+if !exists('b:org_complete_tag_on_insertleave_au')
 	:au orgmode InsertLeave <buffer> :py ORGMODE.plugins[u'TagsProperties'].realign_tags()
-	let b:org_insert_leave_set = 1
+	let b:org_complete_tag_on_insertleave_au = 1
 endif
 endfunction""".encode(u'utf-8'))
 

--- a/ftplugin/orgmode/plugins/TagsProperties.py
+++ b/ftplugin/orgmode/plugins/TagsProperties.py
@@ -197,10 +197,16 @@ else
 endif
 endfunction""".encode(u'utf-8'))
 
-		# this is for all org files opened after this file
-		vim.command(u"au orgmode FileType org :au orgmode InsertLeave <buffer> :py ORGMODE.plugins[u'TagsProperties'].realign_tags()".encode(u'utf-8'))
+		vim.command(u"""function Org_realign_tags_on_insert_leave()
+if !exists('b:org_insert_leave_set')
+	:au orgmode InsertLeave <buffer> :py ORGMODE.plugins[u'TagsProperties'].realign_tags()
+	let b:org_insert_leave_set = 1
+endif
+endfunction""".encode(u'utf-8'))
 
+		# this is for all org files opened after this file
+		vim.command(u"au orgmode FileType org call Org_realign_tags_on_insert_leave()".encode(u'utf-8'))
 		# this is for the current file
-		vim.command(u"au orgmode InsertLeave <buffer> :py ORGMODE.plugins[u'TagsProperties'].realign_tags()".encode(u'utf-8'))
+		vim.command(u"call Org_realign_tags_on_insert_leave()".encode(u'utf-8'))
 
 # vim: set noexpandtab:

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -22,20 +22,21 @@ endif
 " FIXME: Always make org_bold syntax define before org_heading syntax
 "        to make sure that org_heading syntax got higher priority(help :syn-priority) than org_bold.
 "        If there is any other good solution, please help fix it.
+"  \\\\*sinuate*
 if (s:conceal_aggressively == 1)
-    syntax region org_bold      matchgroup=org_border_bold start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  concealends oneline
-    syntax region org_italic    matchgroup=org_border_ital start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  concealends oneline
-    syntax region org_underline matchgroup=org_border_undl start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    concealends oneline
-    syntax region org_code      matchgroup=org_border_code start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    concealends oneline
-    syntax region org_code      matchgroup=org_border_code start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    concealends oneline
-    syntax region org_verbatim  matchgroup=org_border_verb start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  concealends oneline
+   syntax region org_bold      matchgroup=org_border_bold start="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|\(^\|[^\\]\)\zs\*\S\@="     end="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|[^\\]\zs\*\S\@="  concealends oneline
+   syntax region org_italic    matchgroup=org_border_ital start="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|\(^\|[^\\]\)\zs\/\S\@="     end="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|[^\\]\zs\/\S\@="  concealends oneline
+   syntax region org_underline matchgroup=org_border_undl start="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|\(^\|[^\\]\)\zs_\S\@="        end="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|[^\\]\zs_\S\@="     concealends oneline
+   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|\(^\|[^\\]\)\zs=\S\@="        end="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|[^\\]\zs=\S\@="     concealends oneline
+   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs`\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs`\|\(^\|[^\\]\)\zs`\S\@="        end="[^ \\]\zs'\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs'\|[^\\]\zs'\S\@="     concealends oneline
+   syntax region org_verbatim  matchgroup=org_border_verb start="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|\(^\|[^\\]\)\zs\~\S\@="     end="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|[^\\]\zs\~\S\@="  concealends oneline
 else
-    syntax region org_bold      start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  keepend oneline
-    syntax region org_italic    start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  keepend oneline
-    syntax region org_underline start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    keepend oneline
-    syntax region org_code      start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    keepend oneline
-    syntax region org_code      start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    keepend oneline
-    syntax region org_verbatim  start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  keepend oneline
+    syntax region org_bold      start="\S\zs\*\|\*\S\@="     end="\S\zs\*\|\*\S\@="  keepend oneline
+    syntax region org_italic    start="\S\zs\/\|\/\S\@="     end="\S\zs\/\|\/\S\@="  keepend oneline
+    syntax region org_underline start="\S\zs_\|_\S\@="       end="\S\zs_\|_\S\@="    keepend oneline
+    syntax region org_code      start="\S\zs=\|=\S\@="       end="\S\zs=\|=\S\@="    keepend oneline
+    syntax region org_code      start="\S\zs`\|`\S\@="       end="\S\zs'\|'\S\@="    keepend oneline
+    syntax region org_verbatim  start="\S\zs\~\|\~\S\@="     end="\S\zs\~\|\~\S\@="  keepend oneline
 endif
 
 hi def org_bold      term=bold      cterm=bold      gui=bold

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -5,8 +5,10 @@
 " Do we use aggresive conceal?
 if exists("b:org_aggressive_conceal")
     let s:conceal_aggressively=b:org_aggressive_conceal
-else
+elseif exists("g:org_aggressive_conceal")
     let s:conceal_aggressively=g:org_aggressive_conceal
+else
+    let s:conceal_aggressively=0
 endif
 
 " Inline markup {{{1

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -24,12 +24,12 @@ endif
 "        If there is any other good solution, please help fix it.
 "  \\\\*sinuate*
 if (s:conceal_aggressively == 1)
-   syntax region org_bold      matchgroup=org_border_bold start="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|\(^\|[^\\]\)\zs\*\S\@="     end="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|[^\\]\zs\*\S\@="  concealends oneline
-   syntax region org_italic    matchgroup=org_border_ital start="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|\(^\|[^\\]\)\zs\/\S\@="     end="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|[^\\]\zs\/\S\@="  concealends oneline
-   syntax region org_underline matchgroup=org_border_undl start="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|\(^\|[^\\]\)\zs_\S\@="        end="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|[^\\]\zs_\S\@="     concealends oneline
-   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|\(^\|[^\\]\)\zs=\S\@="        end="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|[^\\]\zs=\S\@="     concealends oneline
-   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs`\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs`\|\(^\|[^\\]\)\zs`\S\@="        end="[^ \\]\zs'\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs'\|[^\\]\zs'\S\@="     concealends oneline
-   syntax region org_verbatim  matchgroup=org_border_verb start="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|\(^\|[^\\]\)\zs\~\S\@="     end="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|[^\\]\zs\~\S\@="  concealends oneline
+   syntax region org_bold      matchgroup=org_border_bold start="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|\(^\|[^\\]\)\@<=\*\S\@="     end="[^ \\]\zs\*\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\*\|[^\\]\zs\*\S\@="  concealends oneline
+   syntax region org_italic    matchgroup=org_border_ital start="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|\(^\|[^\\]\)\@<=\/\S\@="     end="[^ \\]\zs\/\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\/\|[^\\]\zs\/\S\@="  concealends oneline
+   syntax region org_underline matchgroup=org_border_undl start="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|\(^\|[^\\]\)\@<=_\S\@="        end="[^ \\]\zs_\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs_\|[^\\]\zs_\S\@="     concealends oneline
+   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|\(^\|[^\\]\)\@<==\S\@="        end="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|[^\\]\zs=\S\@="     concealends oneline
+   syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs`\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs`\|\(^\|[^\\]\)\@<=`\S\@="        end="[^ \\]\zs'\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs'\|[^\\]\zs'\S\@="     concealends oneline
+   syntax region org_verbatim  matchgroup=org_border_verb start="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|\(^\|[^\\]\)\@<=\~\S\@="     end="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|[^\\]\zs\~\S\@="  concealends oneline
 else
     syntax region org_bold      start="\S\zs\*\|\*\S\@="     end="\S\zs\*\|\*\S\@="  keepend oneline
     syntax region org_italic    start="\S\zs\/\|\/\S\@="     end="\S\zs\/\|\/\S\@="  keepend oneline

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -243,7 +243,7 @@ hi def link org_table_separator Type
 
 " Hyperlinks: {{{1
 syntax match hyperlink	"\[\{2}[^][]*\(\]\[[^][]*\)\?\]\{2}" contains=hyperlinkBracketsLeft,hyperlinkURL,hyperlinkBracketsRight containedin=ALL
-syntax match hyperlinkBracketsLeft	contained "\[\{2}"     conceal
+syntax match hyperlinkBracketsLeft	contained "\[\{2}#\?"     conceal
 syntax match hyperlinkURL				    contained "[^][]*\]\[" conceal
 syntax match hyperlinkBracketsRight	contained "\]\{2}"     conceal
 hi def link hyperlink Underlined

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -9,7 +9,7 @@ else
     let s:conceal_aggressively=g:org_aggressive_conceal
 endif
 
-" Inline markup
+" Inline markup {{{1
 " *bold*, /italic/, _underline_, +strike-through+, =code=, ~verbatim~
 " Note:
 " - /italic/ is rendered as reverse in most terms (works fine in gVim, though)
@@ -23,24 +23,30 @@ endif
 "        to make sure that org_heading syntax got higher priority(help :syn-priority) than org_bold.
 "        If there is any other good solution, please help fix it.
 if (s:conceal_aggressively == 1)
-    syntax region org_bold      matchgroup=org_border start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  concealends oneline
-    syntax region org_italic    matchgroup=org_border start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  concealends oneline
-    syntax region org_underline matchgroup=org_border start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    concealends oneline
-    syntax region org_code      matchgroup=org_border start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    concealends oneline
-    syntax region org_code      matchgroup=org_border start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    concealends oneline
-    syntax region org_verbatim  matchgroup=org_border start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  concealends oneline
+    syntax region org_bold      matchgroup=org_border_bold start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  concealends oneline
+    syntax region org_italic    matchgroup=org_border_ital start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  concealends oneline
+    syntax region org_underline matchgroup=org_border_undl start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    concealends oneline
+    syntax region org_code      matchgroup=org_border_code start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    concealends oneline
+    syntax region org_code      matchgroup=org_border_code start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    concealends oneline
+    syntax region org_verbatim  matchgroup=org_border_verb start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  concealends oneline
 else
-    syntax region org_bold      matchgroup=org_border start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  keepend oneline
-    syntax region org_italic    matchgroup=org_border start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  keepend oneline
-    syntax region org_underline matchgroup=org_border start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    keepend oneline
-    syntax region org_code      matchgroup=org_border start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    keepend oneline
-    syntax region org_code      matchgroup=org_border start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    keepend oneline
-    syntax region org_verbatim  matchgroup=org_border start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  keepend oneline
+    syntax region org_bold      start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  keepend oneline
+    syntax region org_italic    start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  keepend oneline
+    syntax region org_underline start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    keepend oneline
+    syntax region org_code      start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    keepend oneline
+    syntax region org_code      start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    keepend oneline
+    syntax region org_verbatim  start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  keepend oneline
 endif
 
 hi def org_bold      term=bold      cterm=bold      gui=bold
 hi def org_italic    term=italic    cterm=italic    gui=italic
 hi def org_underline term=underline cterm=underline gui=underline
+
+if (s:conceal_aggressively == 1)
+    hi link org_border_bold org_bold
+    hi link org_border_ital org_italic
+    hi link org_border_undl org_underline
+endif
 
 " Headings: {{{1
 " Load Settings: {{{2
@@ -259,7 +265,11 @@ hi def link org_table_separator Type
 
 " Hyperlinks: {{{1
 syntax match hyperlink	"\[\{2}[^][]*\(\]\[[^][]*\)\?\]\{2}" contains=hyperlinkBracketsLeft,hyperlinkURL,hyperlinkBracketsRight containedin=ALL
-syntax match hyperlinkBracketsLeft	contained "\[\{2}#\?"     conceal
+if (s:conceal_aggressively == 1)
+    syntax match hyperlinkBracketsLeft	contained "\[\{2}#\?"     conceal
+else
+    syntax match hyperlinkBracketsLeft	contained "\[\{2}"     conceal
+endif
 syntax match hyperlinkURL				    contained "[^][]*\]\[" conceal
 syntax match hyperlinkBracketsRight	contained "\]\{2}"     conceal
 hi def link hyperlink Underlined
@@ -314,11 +324,18 @@ hi def link org_title           Title
 " TODO: http://vim.wikia.com/wiki/Different_syntax_highlighting_within_regions_of_a_file
 syntax match  org_verbatim /^\s*>.*/
 syntax match  org_code     /^\s*:.*/
+
 syntax region org_verbatim start="^\s*#+BEGIN_.*"      end="^\s*#+END_.*"      keepend contains=org_block_delimiter
 syntax region org_code     start="^\s*#+BEGIN_SRC"     end="^\s*#+END_SRC"     keepend contains=org_block_delimiter
 syntax region org_code     start="^\s*#+BEGIN_EXAMPLE" end="^\s*#+END_EXAMPLE" keepend contains=org_block_delimiter
+
 hi def link org_code     String
 hi def link org_verbatim String
+
+if (s:conceal_aggressively==1)
+    hi link org_border_code     org_code
+    hi link org_border_verb     org_verbatim
+endif
 
 " Properties: {{{1
 syn region Error matchgroup=org_properties_delimiter start=/^\s*:PROPERTIES:\s*$/ end=/^\s*:END:\s*$/ contains=org_property keepend

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -374,7 +374,6 @@ if exists('g:loaded_SyntaxRange')
   call SyntaxRange#Include('\\begin[.*]{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\begin{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\\[', '\\\]', 'tex')
-  call SyntaxRange#Include('\$', '\$', 'tex')
 endif
 
 " vi: ft=vim:tw=80:sw=4:ts=4:fdm=marker

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -1,6 +1,13 @@
 " Support org authoring markup as closely as possible
 " (we're adding two markdown-like variants for =code= and blockquotes)
 " -----------------------------------------------------------------------------
+"
+" Do we use aggresive conceal?
+if exists("b:org_aggressive_conceal")
+    let s:conceal_aggressively=b:org_aggressive_conceal
+else
+    let s:conceal_aggressively=g:org_aggressive_conceal
+endif
 
 " Inline markup
 " *bold*, /italic/, _underline_, +strike-through+, =code=, ~verbatim~
@@ -15,12 +22,21 @@
 " FIXME: Always make org_bold syntax define before org_heading syntax
 "        to make sure that org_heading syntax got higher priority(help :syn-priority) than org_bold.
 "        If there is any other good solution, please help fix it.
-syntax region org_bold      start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  keepend oneline
-syntax region org_italic    start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  keepend oneline
-syntax region org_underline start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    keepend oneline
-syntax region org_code      start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    keepend oneline
-syntax region org_code      start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    keepend oneline
-syntax region org_verbatim  start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  keepend oneline
+if (s:conceal_aggressively == 1)
+    syntax region org_bold      matchgroup=org_border start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  concealends oneline
+    syntax region org_italic    matchgroup=org_border start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  concealends oneline
+    syntax region org_underline matchgroup=org_border start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    concealends oneline
+    syntax region org_code      matchgroup=org_border start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    concealends oneline
+    syntax region org_code      matchgroup=org_border start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    concealends oneline
+    syntax region org_verbatim  matchgroup=org_border start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  concealends oneline
+else
+    syntax region org_bold      matchgroup=org_border start="\S\@<=\*\|\*\S\@="   end="\S\@<=\*\|\*\S\@="  keepend oneline
+    syntax region org_italic    matchgroup=org_border start="\S\@<=\/\|\/\S\@="   end="\S\@<=\/\|\/\S\@="  keepend oneline
+    syntax region org_underline matchgroup=org_border start="\S\@<=_\|_\S\@="       end="\S\@<=_\|_\S\@="    keepend oneline
+    syntax region org_code      matchgroup=org_border start="\S\@<==\|=\S\@="       end="\S\@<==\|=\S\@="    keepend oneline
+    syntax region org_code      matchgroup=org_border start="\S\@<=`\|`\S\@="       end="\S\@<='\|'\S\@="    keepend oneline
+    syntax region org_verbatim  matchgroup=org_border start="\S\@<=\~\|\~\S\@="     end="\S\@<=\~\|\~\S\@="  keepend oneline
+endif
 
 hi def org_bold      term=bold      cterm=bold      gui=bold
 hi def org_italic    term=italic    cterm=italic    gui=italic
@@ -341,6 +357,7 @@ if exists('g:loaded_SyntaxRange')
   call SyntaxRange#Include('\\begin[.*]{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\begin{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\\[', '\\\]', 'tex')
+  call SyntaxRange#Include('\$', '\$', 'tex')
 endif
 
 " vi: ft=vim:tw=80:sw=4:ts=4:fdm=marker


### PR DESCRIPTION
I modified a bit. Making `<localleader>caA` as `<localleader>caa` single file
version. `<localleader>caT` as `<localleader>cat` single file version.
Effectively, I made your `<localleader>caT` into `<localleader>caA` and added
a new `<localleader>caT`.

Also, I checked on emac's orgmode. It's single file timeline is a bit like our
`<localleader>caA` but different in a way that not only active agenda, but
timestamped headers(with state Done or else) are listed in their overview. So
I can't treat your suggestion as a timeline equivalent. Rather, I'd take it as
a meaningful single buffer version for weekly overview and todolist overview.
Are you OK with it? Please merge it into your PR if you consent.
